### PR TITLE
update init() for wordpress v6.x; add option to hide the field on pos…

### DIFF
--- a/src/ACF_Field_Unique_ID.php
+++ b/src/ACF_Field_Unique_ID.php
@@ -63,7 +63,6 @@ class ACF_Field_Unique_ID extends acf_field {
                 '<style scoped>.acf-field-%s{display:none;}</style>',
                 explode('_', $field['key'])[1],
             );
-            return;
         }
 
         printf(

--- a/src/ACF_Field_Unique_ID.php
+++ b/src/ACF_Field_Unique_ID.php
@@ -1,66 +1,118 @@
 <?php
 
+/**
+ * Version: 3.0.0
+ */
+
 namespace PhilipNewcomer\ACF_Unique_ID_Field;
 
 use acf_field;
 
+if (!defined('ABSPATH')) {
+    exit();
+}
+
 class ACF_Field_Unique_ID extends acf_field {
+    /**
+     * Controls field type visibilty in REST requests.
+     *
+     * @var bool
+     */
+    public $show_in_rest = true;
 
-	/**
-	 * Initialize the class.
-	 */
-	public static function init() {
-		add_action(
-			'acf/include_field_types',
-			function() {
-				if ( ! class_exists( 'acf_field' ) ) {
-					return;
-				}
+    /**
+     * Initialize the class.
+     */
+    public static function init() {
+        /**
+         * Registers the ACF field type.
+         */
 
-				new static();
-			}
-		);
-	}
+        add_action('init', function () {
+            if (!function_exists('acf_register_field_type')) {
+                return;
+            }
 
-	/**
-	 * Initialize the field.
-	 */
-	public function __construct() {
-		$this->name     = 'unique_id';
-		$this->label    = 'Unique ID';
-		$this->category = 'basic';
+            acf_register_field_type(new static());
+        });
+    }
 
-		parent::__construct();
-	}
+    /**
+     * Initialize the field.
+     */
+    public function __construct() {
+        $this->name = 'unique_id';
+        $this->label = 'Unique ID';
+        $this->category = 'basic';
 
-	/**
-	 * Render the HTML field.
-	 *
-	 * @param array $field The field data.
-	 */
-	public function render_field( $field ) {
-		printf(
-			'<input type="text" name="%s" value="%s" readonly>',
-			esc_attr( $field['name'] ),
-			esc_attr( $field['value'] )
-		);
-	}
+        parent::__construct();
+    }
 
-	/**
-	 * Define the unique ID if one does not already exist.
-	 *
-	 * @param string $value   The field value.
-	 * @param int    $post_id The post ID.
-	 * @param array  $field   The field data.
-	 *
-	 * @return string The filtered value.
-	 */
-	public function update_value( $value, $post_id, $field ) {
+    /**
+     * Render the HTML field.
+     *
+     * @param array $field The field data.
+     */
+    public function render_field($field) {
+        // Debug
+        // printf('<code>%s</code>', var_dump($field));
 
-		if ( ! empty( $value ) ) {
-			return $value;
-		}
+        // Check if the 'hide_on_post_edit' setting is true
+        if (!empty($field['hide_on_post_edit'])) {
+            printf(
+                '<style scoped>.acf-field-%s{display:none;}</style>',
+                explode('_', $field['key'])[1],
+            );
+            return;
+        }
 
-		return uniqid();
-	}
+        printf(
+            '<input type="text" name="%s" value="%s" readonly>',
+            esc_attr($field['name']),
+            esc_attr($field['value']),
+        );
+    }
+
+    /**
+     * Settings to display when users configure a field of this type.
+     *
+     * These settings appear on the ACF “Edit Field Group” admin page when
+     * setting up the field.
+     *
+     * @param array $field
+     * @return void
+     */
+    public function render_field_settings($field) {
+        /*
+         * Repeat for each setting you wish to display for this field type.
+         */
+        acf_render_field_setting($field, [
+            'label' => 'Hide on post edit',
+            'instructions' =>
+                'Check this box to hide the field when editing a post.',
+            'type' => 'true_false',
+            'name' => 'hide_on_post_edit',
+            'ui' => 1,
+        ]);
+
+        // To render field settings on other tabs in ACF 6.0+:
+        // https://www.advancedcustomfields.com/resources/adding-custom-settings-fields/#moving-field-setting
+    }
+
+    /**
+     * Define the unique ID if one does not already exist.
+     *
+     * @param string $value   The field value.
+     * @param int    $post_id The post ID.
+     * @param array  $field   The field data.
+     *
+     * @return string The filtered value.
+     */
+    public function update_value($value, $post_id, $field) {
+        if (!empty($value)) {
+            return $value;
+        }
+
+        return uniqid();
+    }
 }


### PR DESCRIPTION
I update the static init function to add support for new WP version.

I added option to hide the field from admin panel when editing post.

![image](https://github.com/philipnewcomer/ACF-Unique-ID-Field/assets/11756007/af5b4628-1fc8-493c-a0ac-8276bc4e7880)
