### PR TITLE
Replaced uniqid with a uuid function.

### DIFF
--- a/src/ACF_Field_Unique_ID.php
+++ b/src/ACF_Field_Unique_ID.php
@@ -61,6 +61,18 @@ class ACF_Field_Unique_ID extends acf_field {
 			return $value;
 		}
 
-		return uniqid();
+		return uuidv4();
+	}
+
+	/**
+         * Function to create a unique UUID
+	 */
+	function uuidv4() {
+		$data = random_bytes(16);
+		
+		$data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set version to 0100
+		$data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits 6-7 to 10
+		
+		return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
 	}
 }


### PR DESCRIPTION
Did some research on the `uniqid();` function, and the chance for a conflict seems a bit high. I've also came across [this post](https://stackoverflow.com/questions/4070110/how-unique-is-uniqid) discussing the issues with it.

I can't take credit for the UUID code in my pull request. I found [this answer](https://stackoverflow.com/a/15875555) when researching a PHP function to generate UUID's.

Another option is to use the WordPress `wp_generate_uuid4` [function](https://developer.wordpress.org/reference/functions/wp_generate_uuid4/), but the code from Stack Overflow doesn't seem as reliant on WordPress, though since this is a package for ACF, that probably doesn't matter.

Hope you pull in my changes or consider using a different function to generate these IDs!